### PR TITLE
Loosen up the Fractal version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "league/fractal": "^0.13.0"
+        "league/fractal": "~0.13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This changes the constraint from covering 0.13.* to covering 0.13 - 0.9

The Fractal releases have been generally changing like so 0.13.0, 0.14.0, 0.15.0, etc

This change will allow us to bring in these newer versions 